### PR TITLE
mounted 生命周期当中无法访问$slots对象，导致无法添加事件监听。

### DIFF
--- a/packages/eno-auto-scroll/src/EnoAutoScroll.vue
+++ b/packages/eno-auto-scroll/src/EnoAutoScroll.vue
@@ -97,6 +97,7 @@ export default {
 
     },
     updated() {
+        this.initScrollListener();
         if (this.$_checkForSlotContentLengthChange() && this.$refs.enoAutoScrollContent) {
             this.startScroll();
         }
@@ -104,12 +105,6 @@ export default {
 
     beforeDestroy() {
         this.pauseScroll();
-    },
-    mounted() {
-        this.initScrollListener();
-        if (this.$_checkForSlotContentLengthChange() && this.$refs.enoAutoScrollContent) {
-            this.startScroll();
-        }
     },
     methods: {
         /* _____________________________________________________________________________________ */


### PR DESCRIPTION
将mounted生命周期移除，事件监听移到到updated生命周期当中，因为在mounted生命周期当中$slots为空对象 即 :{}。…